### PR TITLE
Add Google Search Console verification file

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -13,7 +13,8 @@
 <link rel="stylesheet" href="{{ $css.RelPermalink }}?{{- hugo.Version -}}">
 
 {{- if .IsHome -}}
-{{- hugo.Generator -}}
+{{- hugo.Generator }}
+<meta name="google-site-verification" content="NMOesOkCLPuh0w1wyYyMje6YCd3XpJ30lrK5RfvEj7g" />
 {{- end }}
 <script src="/js/jquery.min.js"></script>
 <script src="/js/bootstrap.min.js"></script>

--- a/static/google8b0b779935bc76f8.html
+++ b/static/google8b0b779935bc76f8.html
@@ -1,0 +1,1 @@
+google-site-verification: google8b0b779935bc76f8.html


### PR DESCRIPTION
This adds verification for access to stats on https://search.google.com/search-console/about.
We get a lot of traffic from Google - with this we can see how and why they get to the site.
Happy to add Trimble folks to view access to the stats.