### PR TITLE
switch from deprecated UA to GA4

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -5,7 +5,7 @@ locale: en-US
 
 enableInlineShortcodes: true
 enableGitInfo: true
-googleAnalytics: "UA-106389617-3"
+googleAnalytics: "G-JSL7J81XML"
 
 params:
   title: Developer Guidelines


### PR DESCRIPTION
UA is deprecated and all data will be deleted. This PR switches the tracking ID to a GA4 property.
REF: https://support.google.com/analytics/answer/11583528?hl=en

Note: we also have Plausible Analytics.