### PR TITLE
Fixes for CODEOWNERS page

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: streetsidesoftware/cspell-action@v2
         with:
+          check_dot_files: false
+          incremental_files_only: true
           inline: warning
           strict: false
-          incremental_files_only: true

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Developer Guidelines website is run by the Developer Guidelines Working Grou
 - Ryan Kuhn - ryan_kuhn@trimble.com
 - Christian Oliff - christian_oliff@trimble.com
 - Ian Welch - ian_welch@trimble.com
-- Matthew Dexter- matthew_dexter@trimble.com
+- Matthew Dexter - matthew_dexter@trimble.com
 
 ## Getting Involved
 

--- a/assets/css/_codefences.scss
+++ b/assets/css/_codefences.scss
@@ -256,4 +256,9 @@
   color: #40a070;
 } /* Literal.Number.Integer.Long */
 
+[data-url="/innersource/codeowners-configuration/"] {
+  span.gh {
+    opacity: 0.7;
+  }
+}
 /*! purgecss end ignore */

--- a/content/code-style/code-style-css.md
+++ b/content/code-style/code-style-css.md
@@ -20,7 +20,7 @@ The [Code Guide](https://codeguide.co/#css) also provides excellent guidance for
 
 Many IDE's provide formatting, linting and hinting support.
 
-- [Editorconfig](https://editorconfig.org/)
+- [EditorConfig](https://editorconfig.org/)
 - [Stylelint](https://stylelint.io)
 
 We recommend linting CSS with [Stylelint](https://stylelint.io). The [stylelint-config-standard](https://github.com/stylelint/stylelint-config-standard)

--- a/content/innersource/codeowners-configuration.md
+++ b/content/innersource/codeowners-configuration.md
@@ -3,6 +3,7 @@ title: "Code Owners Configuration"
 layout: "single"
 description: ""
 innersource: true
+hideToc: true
 ---
 
 Follow the steps below in order to configure the CODEOWNERS plugin:
@@ -13,26 +14,26 @@ Follow the steps below in order to configure the CODEOWNERS plugin:
 
 - To configure the owners of the projects and files of the repository, read the following instructions:
 
-```txt
-# Either put this in a file called CODEOWNERS or .bitbucket/CODEOWNERS
+```md
+# Either put this in a file called CODEOWNERS
 # Every line is a file pattern that is followed by one or more code owners.
 # Lines starting with # are comments.
 
 # This user will be the default owner for everything in the repo.
-*                        @AllMighty_Owner@trimble.com
+*                        AllMighty_Owner@trimble.com
 
 # Ordering is important! The last matching file pattern has the highest precedence.
 # So if only a Java file is in the pull request, The_Java_Guy@trimble is the code owner
 # and not the default owner AllMighty_Owner@trimble.
-*.java                   @The_Java_Guy@trimble.com
+*.java                   The_Java_Guy@trimble.com
 
 # You can also use Bitbucket groups which start with '@@' compared to single users.
 # This will add all members of the Bitbucket group JSExperts.
-*.js                     @Some_Guy_Paul@trimble.com @@JSExperts
+*.js                     Some_Guy_Paul@trimble.com @@JSExperts
 
 # If you want, you can define your own code owner groups instead of using Bitbucket groups.
 # This will define a new group MyDevs, both including users and other groups:
-@@@MyDevs                @Some_Guy_Paul@trimble.com  @The_Java_Guy@trimble.com @@JSDevs
+@@@MyDevs                Some_Guy_Paul@trimble.com  The_Java_Guy@trimble.com @@JSDevs
 
 # For Bitbucket users and groups with spaces in their name, put them into double quotes.
 *.ts                     @@"Dev Ops Team"
@@ -41,12 +42,12 @@ Follow the steps below in order to configure the CODEOWNERS plugin:
 "a/path with spaces/*"   docs@trimble.com
 
 # Files starting with a `#` or a `!` can still be used by escaping them.
-\#myfile.rb              @Some_Guy_Paul@trimble.com
+\#myfile.rb              Some_Guy_Paul@trimble.com
 \!your-file.rb           @@MyDevs
 
 # AnnTheScalaPro is the code owner of all files in the /src/main/scala directory at
 # the root and all its descendants (e.g., /src/main/scala/com/x/y/z.scala).
-/src/main/scala/         @AnnTheScalaPro@trimble.com
+/src/main/scala/         AnnTheScalaPro@trimble.com
 
 # ci/* will match all files in the directory ci, but not deeper in
 # the directory hierarchy (so ci/jobs/prod.yml will not match).
@@ -68,7 +69,7 @@ groovy/                  @@MyDevs
 
 # It is important to protect CODEOWNERS file as well because otherwise it can get deleted
 # or moved within a pull request; so we want to assign a code owner to it which can prevent this
-CODEOWNERS               @AllMighty_Owner@trimble.com
+CODEOWNERS               AllMighty_Owner@trimble.com
 ```
 
 [Learn more about Code Owners for Bitbucket](https://mibexsoftware.atlassian.net/wiki/spaces/CODEOWNERS/overview)

--- a/content/innersource/project-documentation.md
+++ b/content/innersource/project-documentation.md
@@ -23,7 +23,7 @@ innersource: true
 ## Project documentation
 
 Because you want to promote both the consumption and contribution of your software, the documentation guidelines should be split between these two type of personas.
-We recommend to storing all the documentation files in BitBucket, in the Markdown format, so it is closer to the code it documents.
+We recommend to storing all the documentation files in the repository, in the Markdown format, so it is closer to the code it documents.
 As Markdown format is not appropriate for certain cases, (e.g. a sequence diagram), we recommend using other tools (e.g. Miro) and adding a link into the Markdown file.
 
 ### Consumer

--- a/content/innersource/publish-documentation.md
+++ b/content/innersource/publish-documentation.md
@@ -3,6 +3,7 @@ title: "Publishing An InnerSource project"
 layout: "single"
 description: ""
 innersource: true
+hideToc: true
 ---
 
 Opening up a project to InnerSource is one thing, but it is equally important to get users to adopt and contribute to it. It is therefore highly advisable that you have a way of publishing the project and making the InnerSource documentation available.

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -22,6 +22,7 @@ module.exports = {
         "d-block",
         "d-inline-block",
         "footer",
+        "gh",
         "highlight",
         "language-txt",
         "main",


### PR DESCRIPTION
Email addresses should not begin with @
Adds nice syntax highlighting to the CODEOWNERS example (comments now appear in a different color)

PREVIEW:

![image](https://user-images.githubusercontent.com/1212885/196170440-4ebcee93-1ed1-42d0-bdf7-2601f592edb8.png)

PR also includes various other small fixes (grammar, linting and formatting).