### PR TITLE
Remove contacts from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,13 @@
 
 The Developer Guidelines website is run by the Developer Guidelines Working Group.
 
-**Owner**:
-
-- Jeff Doolittle - jeffrey_doolittle@trimble.com
-
-**Trusted Committers**:
-
-- Ryan Kuhn - ryan_kuhn@trimble.com
-- Christian Oliff - christian_oliff@trimble.com
-- Ian Welch - ian_welch@trimble.com
-- Matthew Dexter - matthew_dexter@trimble.com
-
 ## Getting Involved
 
 Contributions to these guidelines are very welcome. Please view [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ### Tracking and reporting issues/suggestions with these guidelines
 
-Please email the [Developer Guidelines Working Group](mailto:dev-guidelines-working-group-ug@trimble.com)
+Please email the [Developer Guidelines Working Group](mailto:devguide-ug@trimble.com)
 
 ## Links
 
@@ -36,7 +25,6 @@ Please email the [Developer Guidelines Working Group](mailto:dev-guidelines-work
 | Resource           | Link                                                                                                       |
 | ------------------ | ---------------------------------------------------------------------------------------------------------- |
 | Google Lighthouse  | https://googlechrome.github.io/lighthouse/viewer/?psiurl=https://devguide.trimble.com                      |
-| OpenGraph Test     | https://opengraphcheck.com/result.php?url=https://devguide.trimble.com                                     |
 | Page Speed Test    | https://pagespeed.web.dev/report?utm_source=psi&utm_medium=redirect&url=https%3A%2F%2Fdevguide.trimble.com |
 | Website Grader     | https://website.grader.com/results/devguide.trimble.com                                                    |
 | SEO, Social & More | https://www.seoptimer.com/devguide.trimble.com                                                             |


### PR DESCRIPTION
- Removes names and email addresses of trusted committers.
- Change email address for feedback to: devguide-ug@trimble.com
- Remove dead-link to https://opengraphcheck.com