### PR TITLE
Dependabot config update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,11 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: monthly
+      interval: weekly
+    labels:
+      - dependencies
     versioning-strategy: increase
+    open-pull-requests-limit: 1
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
reduce open pull request limit so we don't use all our environment deploy preview URLs