### PR TITLE
Add PEP 484 to Python Code Style

### DIFF
--- a/content/code-style/code-style-python.md
+++ b/content/code-style/code-style-python.md
@@ -60,8 +60,32 @@ repos:
         verbose: true
 ```
 
+## Other recommended practices
+
+It's advised to write type annotated code whenever possible. The following PEP is relevant to this:
+
+- **[PEP 484 -- Type Hints](https://www.python.org/dev/peps/pep-0484)**<br>
+PEP 484 introduces type hints to Python code. It enables annotating function and variable types to improve code clarity and maintainability.
+
+Type-checking code at build time is possible with type checking tools such as [mypy](https://mypy.readthedocs.io/en/stable/index.html). Conscious rule violations can be silenced using:
+
+```python
+# type: ignore
+```
+
+mypy can be added to the `pre-commit-config.yaml` in the following way:
+
+```yaml
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: ''  # Use the sha / tag you want to point at
+    hooks:
+    -   id: mypy
+```
+
 ## Bibliography
 
+- [mypy](https://mypy.readthedocs.io/en/stable/index.html)
 - [PEP 8](https://www.python.org/dev/peps/pep-0008/)
 - [PEP 257](https://www.python.org/dev/peps/pep-0257/)
+- [PEP 484](https://www.python.org/dev/peps/pep-0484)
 - [Pylint](https://pylint.pycqa.org/en/latest/)


### PR DESCRIPTION
I would like to suggest adding type hints to the Python Code Style page.

## Reasoning

In my opinion, type hints, for the most part, greatly improve code readability/maintainability/reusability by enabling function annotations. It makes it much easier to catch errors already during development, and understand and work with other people's code. I read that large companies such as Dropbox and Microsoft also use it.

## Linter

I added mypy as the weapon of choice. It's a linter that uses function annotations and in this way allows for static type-checking while writing code. Alternatively, pyright or pytype could be used - but I personally don't have any experience. I'm open for suggestions!

## Implementation in the PR

I added it to the standards as a "soft" recommendation with a new `Other recommended practices` section, since I understand in some specific cases, it may be hard to apply type hints. For example when working with a large legacy codebase. But even then, there are ways to "cheat" as a last resort, for example by using the "Any" type, or silencing errors with `# type: ignore`. Also, mypy has a [great documentation](https://mypy.readthedocs.io/en/stable/existing_code.html) covering this scenario.

Very much open to feedback. Thank you for taking the time to review.