### PR TITLE
Fix two broken links I noticed

### DIFF
--- a/content/development-practises/open-source-usage.md
+++ b/content/development-practises/open-source-usage.md
@@ -17,6 +17,6 @@ are opening up and sharing their IP.
 where you technically have given up ownership of the IP of the software that
 you create.
 
-For this reason, Trimble has a [Comprehensive Open Source Policy](https://sites.google.com/trimble.com/open-source/home/policy),
+For this reason, Trimble has a [Comprehensive Open Source Policy](https://drive.google.com/file/d/1abJNdcwWrpIyTTHsySMi3eyzLcY70zAX/view),
 that you should reference and live by as you take advantage of world of open
 source software.

--- a/hugo.yml
+++ b/hugo.yml
@@ -11,7 +11,7 @@ params:
   title: Developer Guidelines
   copyrightHolder: "Trimble Inc."
   author: "Trimble"
-  GitHubRepo: "https://github.com/orgs/trimble-oss/devguide"
+  GitHubRepo: "https://github.com/trimble-oss/devguide"
   images:
     - https://devguide.trimble.com/img/preview.png
 


### PR DESCRIPTION
- "Comprehensive Open Source Policy" on "Open Source Usage" page
- "View on GitHub" button generated at the bottom of every page